### PR TITLE
Adding project version to the execution creation in QAReporter

### DIFF
--- a/wt_performance/project-example/upload_to_qareporter.sh
+++ b/wt_performance/project-example/upload_to_qareporter.sh
@@ -22,7 +22,7 @@ if (( ${#PROJECT_OBJECT} )); then
   PROJECT_ID=$(echo "${PROJECT_OBJECT}" | awk -v FS="(project_id\":|,)" '{print $2}')
   EXECUTION_DATE=$(date +"%Y-%m-%d %H:%M")
 
-  EXECUTION_OBJECT=$(curl -X POST -d "project-id=${PROJECT_ID}&execution-name=autoexecution_${PERFORMANCE_VERSION_NUMBER}&execution-date=${EXECUTION_DATE}" ${QA_REPORTER_URL}/api/1.0/performance/executions/)
+  EXECUTION_OBJECT=$(curl -X POST -d "project-id=${PROJECT_ID}&project_version=${PERFORMANCE_VERSION_NUMBER}&execution-name=autoexecution_${PERFORMANCE_VERSION_NUMBER}&execution-date=${EXECUTION_DATE}" ${QA_REPORTER_URL}/api/1.0/performance/executions/)
   EXECUTION_ID=$(echo "${EXECUTION_OBJECT}" | awk -v FS="(execution_id\":|})" '{print $2}')
 
 

--- a/wt_performance/project-example/upload_to_qareporter.sh
+++ b/wt_performance/project-example/upload_to_qareporter.sh
@@ -22,7 +22,7 @@ if (( ${#PROJECT_OBJECT} )); then
   PROJECT_ID=$(echo "${PROJECT_OBJECT}" | awk -v FS="(project_id\":|,)" '{print $2}')
   EXECUTION_DATE=$(date +"%Y-%m-%d %H:%M")
 
-  EXECUTION_OBJECT=$(curl -X POST -d "project-id=${PROJECT_ID}&project_version=${PERFORMANCE_VERSION_NUMBER}&execution-name=autoexecution_${PERFORMANCE_VERSION_NUMBER}&execution-date=${EXECUTION_DATE}" ${QA_REPORTER_URL}/api/1.0/performance/executions/)
+  EXECUTION_OBJECT=$(curl -X POST -d "project-id=${PROJECT_ID}&project-version=${PERFORMANCE_VERSION_NUMBER}&execution-name=autoexecution_${PERFORMANCE_VERSION_NUMBER}&execution-date=${EXECUTION_DATE}" ${QA_REPORTER_URL}/api/1.0/performance/executions/)
   EXECUTION_ID=$(echo "${EXECUTION_OBJECT}" | awk -v FS="(execution_id\":|})" '{print $2}')
 
 


### PR DESCRIPTION
In order to add project version in the new performance report template, a parameter called "project-version" has been added to "upload_to_qareporter.sh file", in the POST request that creates the new execution on QAReporter.