### PR TITLE
Qawtp 137 parametrize ia prompt

### DIFF
--- a/ia/AzureOpenAI/Assistants/PerformanceAnalizer.py
+++ b/ia/AzureOpenAI/Assistants/PerformanceAnalizer.py
@@ -53,10 +53,9 @@ class AzureAssistantManager:
         )
         print(f"File with ID {file_id} added to the assistant.")
 
-    def execute_assistant(self, instructions="Ejecuta las intrucciones"):
+    def execute_assistant(self, labels, percentile):
         """
         Creates and executes a thread to run the assistant.
-        :param instructions: Instructions to execute (default: 'Execute instructions').
         :return: Thread ID for the execution.
         """
         assistant = self.client.beta.assistants.retrieve(self.assistant_id)
@@ -68,7 +67,11 @@ class AzureAssistantManager:
         message = self.client.beta.threads.messages.create(
             thread_id=thread.id,
             role="user",
-            content="Ejecuta",
+            content=f"""
+                Ignora las labels y el percentil que tienes en las instrucciones por defecto, y ejecuta con los siguientes parámetros:
+                - Labels: '{labels}'
+                - Percentil: '{percentile}'
+            """
         )
         thread_messages = self.client.beta.threads.messages.list(thread.id)
         print(thread_messages.model_dump_json(indent=2))
@@ -134,6 +137,8 @@ if __name__ == "__main__":
     API_VERSION = "2024-10-01-preview"
     AZURE_ENDPOINT = "https://chatgpt-qa-licenses.openai.azure.com/"
     ASSISTANT_ID = "asst_yZPBn70DcKVh4YCRdYP10KVr"
+    LABELS = os.environ("LABELS")
+    PERCENTILE = os.environ.get("PERCENTILE", "90")
     # Initialize manager
     manager = AzureAssistantManager(API_KEY, API_VERSION, AZURE_ENDPOINT, ASSISTANT_ID)
 
@@ -147,7 +152,7 @@ if __name__ == "__main__":
     manager.associate_file_with_assistant(uploaded_file.id)
 
     # Step 4: Execute the assistant and monitor execution
-    thread_id = manager.execute_assistant()  # Save the returned thread_id
+    thread_id = manager.execute_assistant(LABELS, PERCENTILE)  # Save the returned thread_id
 
     # Step 5: Download results using the correct thread ID
     manager.download_results(thread_id=thread_id)

--- a/ia/AzureOpenAI/Assistants/PerformanceAnalizer.py
+++ b/ia/AzureOpenAI/Assistants/PerformanceAnalizer.py
@@ -137,9 +137,11 @@ if __name__ == "__main__":
     API_VERSION = "2024-10-01-preview"
     AZURE_ENDPOINT = "https://chatgpt-qa-licenses.openai.azure.com/"
     ASSISTANT_ID = "asst_yZPBn70DcKVh4YCRdYP10KVr"
-    LABELS = os.environ("LABELS")
+    LABELS = os.environ["LABELS"]
     PERCENTILE = os.environ.get("PERCENTILE", "90")
     # Initialize manager
+    if not LABELS:
+        raise ValueError("LABELS está vacío. Saliendo del programa.")
     manager = AzureAssistantManager(API_KEY, API_VERSION, AZURE_ENDPOINT, ASSISTANT_ID)
 
     # Step 1: List and delete all files

--- a/ia/AzureOpenAI/README.md
+++ b/ia/AzureOpenAI/README.md
@@ -14,11 +14,13 @@ Sigue estos pasos:
   3. FAIL si es mayor del 5%
 ```
 
-2. Create a env variable for the Azure OpenAI API key 
+2. Create a env variable for the Azure OpenAI API key, Labels and Percentile (optional, by default 90)
 
 
 ```bash
 export AZURE_OPENAI_API_KEY=sk-xxxxxxxxxxxxxx
+export LABELS="label-1, label-2" # put the LABELS you want, separated by a comma and a space
+export PERCENTILE="90" # you can choose the percentile with which to generate the graphs by changing the value of this variable
 ```
 
 3.  Copy locust_results.csv file with locust results for a specific test in  content root folder
@@ -31,7 +33,7 @@ cp locust_results.csv ia/AzureOpenAI/Assistant
 ```bash
 
 docker build -t performanceanalizer:0.0.1 .
-docker rm -f performanceanalizer; docker run -v .:/app --name performanceanalizer -e AZURE_OPENAI_API_KEY=$AZURE_OPENAI_API_KEY performanceanalizer:0.0.1
+docker rm -f performanceanalizer; docker run -v .:/app --name performanceanalizer -e AZURE_OPENAI_API_KEY=$AZURE_OPENAI_API_KEY -e LABELS=$LABELS -e PERCENTILE=$PERCENTILE performanceanalizer:0.0.1
 ```
 These commands will create 2 images in img folder using Novum performance test example inside assistant, and a doc in docs folder with the results of the test.
 


### PR DESCRIPTION
Se añade la parametrización de los labels y el percentil con el que ejecutar el asistente.
La solución por la que se ha optado ha sido solicitarle al asistente que ignore de sus instrucciones principales, los labels y percentile establecidos y que utilice los enviados en el prompt

Testeado con un csv con labels variados y distintos a la anteriror pr para asegurarnos que es capaz de filtrar los labels que se le solicitan.

Se cumple parte de esta tarea tambien https://jira.tid.es/browse/QAWTP-141